### PR TITLE
remove memozing Cell

### DIFF
--- a/src/final/06.extra-2.js
+++ b/src/final/06.extra-2.js
@@ -110,7 +110,6 @@ function Cell({row, column}) {
   const cell = state.grid[row][column]
   return <CellImpl cell={cell} row={row} column={column} />
 }
-Cell = React.memo(Cell)
 
 function CellImpl({cell, row, column}) {
   const dispatch = useAppDispatch()


### PR DESCRIPTION
memoizing the "middle-man” component `Cell` doesn't prevent its rerendering, because it's consuming `useAppState()`.